### PR TITLE
Combine street and number into 1 query parameter

### DIFF
--- a/app/controllers/geo/NominatimQuery.java
+++ b/app/controllers/geo/NominatimQuery.java
@@ -13,6 +13,15 @@ import org.json.JSONObject;
 
 public class NominatimQuery {
 
+	public static JSONObject getFirstHit(final String aStreetPlusNumber, final String aCity, final String aCountry)
+			throws JSONException, IOException {
+		String queryString = String
+				.format("http://nominatim.openstreetmap.org/search.php?q=%s%s%s%s%s&addressdetails=1&format=json", //
+						aStreetPlusNumber, "%2C+", aCity, "%2C+", aCountry)
+				.replaceAll(" ", "%20");
+		return readJsonArrayFromUrl(queryString).getJSONObject(0);
+	}
+
 	public static JSONObject getFirstHit(final String aStreet, final String aNumber, final String aCity,
 			final String aCountry) throws JSONException, IOException {
 		String queryString = String

--- a/test/GeoInformatorTest.java
+++ b/test/GeoInformatorTest.java
@@ -30,41 +30,37 @@ public class GeoInformatorTest {
 
 	@Test
 	public void testPostcode() throws JSONException, IOException {
-		String street = "Jülicher Straße";
-		String number = "6";
+		String street = "Jülicher Straße 6";
 		String city = "Köln";
 		String country = "Germany";
-		String postalCode = contentAsString(GeoInformator.getPostCode(street, number, city, country));
+		String postalCode = contentAsString(GeoInformator.getPostCode(street, city, country));
 		assertEquals("50674", postalCode);
 	}
 
 	@Test
 	public void testLatLong() throws JSONException, IOException {
-		String street = "Jülicher Straße";
-		String number = "6";
+		String street = "Jülicher Straße 6";
 		String city = "Köln";
 		String country = "Germany";
-		String latLong = GeoInformator.getLatLong(street, number, city, country).toString();
+		String latLong = GeoInformator.getLatLong(street, city, country).toString();
 		assertEquals("{\"latitude\":\"50.9341361\",\"longitude\":\"6.93551400842729\"}", latLong);
 	}
 
 	@Test
 	public void testLat() throws JSONException, IOException {
-		String street = "Jülicher Straße";
-		String number = "6";
+		String street = "Jülicher Straße 6";
 		String city = "Köln";
 		String country = "Germany";
-		String latitude = contentAsString(GeoInformator.getLat(street, number, city, country));
+		String latitude = contentAsString(GeoInformator.getLat(street, city, country));
 		assertEquals("50.9341361", latitude);
 	}
 
 	@Test
 	public void testLong() throws JSONException, IOException {
-		String street = "Jülicher Straße";
-		String number = "6";
+		String street = "Jülicher Straße 6";
 		String city = "Köln";
 		String country = "Germany";
-		String longitude = contentAsString(GeoInformator.getLong(street, number, city, country));
+		String longitude = contentAsString(GeoInformator.getLong(street, city, country));
 		assertEquals("6.93551400842729", longitude);
 	}
 


### PR DESCRIPTION
Due to the data structure of DBS data, it is from now on preferred to have street and number being combined in one parameter. E. g. "Jülicher Straße", "6" now is "Jülicher Straße 6". Nevertheless, there are overloaded methods in GeoInformator that still serve functionality for street and number being separated.
