### PR TITLE
Use embedded Elasticsearch index for geodata service

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,14 +1,12 @@
-import play.Project._
-
 name := """geodata"""
 
 version := "1.0-SNAPSHOT"
 
-libraryDependencies ++= Seq(
-  "org.webjars" %% "webjars-play" % "2.2.2", 
-  "org.webjars" % "bootstrap" % "2.3.1",
-  "com.fasterxml.jackson.core" % "jackson-core" % "2.4.3",
-  "org.elasticsearch" % "elasticsearch" % "1.3.6",
-  "org.json" % "json" % "20141113")
+lazy val root = (project in file(".")).enablePlugins(PlayJava)
 
-playJavaSettings
+scalaVersion := "2.11.1"
+
+libraryDependencies ++= Seq(
+  "com.fasterxml.jackson.core" % "jackson-core" % "2.4.3",
+  "org.elasticsearch" % "elasticsearch" % "2.3.2" exclude ("io.netty", "netty"),
+  "org.json" % "json" % "20141113")

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -7,3 +7,6 @@ application.langs="en"
 logger.root=ERROR
 logger.play=INFO
 logger.application=DEBUG
+
+index.es.port.http=7211
+index.es.port.tcp=7311

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -8,5 +8,5 @@ logger.root=ERROR
 logger.play=INFO
 logger.application=DEBUG
 
-index.es.port.http=7211
-index.es.port.tcp=7311
+index.es.port.http=9201
+index.es.port.tcp=9301

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -8,5 +8,5 @@ logger.root=ERROR
 logger.play=INFO
 logger.application=DEBUG
 
-index.es.port.http=9201
-index.es.port.tcp=9301
+index.es.port.http=7411
+index.es.port.tcp=7511

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Tue Sep 08 17:58:56 CEST 2015
 template.uuid=b7274e52-c226-4deb-bb0e-ab2fdb8f4767
-sbt.version=0.13.2
+sbt.version=0.13.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,4 +5,4 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.2.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.4")


### PR DESCRIPTION
Instead of a stand-alone Elasticsearch instance, use an embedded Elasticsearch that is created on startup if it doesn't exist already. 

Will resolve #36 
