### PR TITLE
Add script to restart instances solely by monit

### DIFF
--- a/monit_restart.sh
+++ b/monit_restart.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+USAGE="<GIT REPO NAME> {start|stop} <PORT> [<JAVA OPTS>]"
+
+if [ $# -lt 3 ]; then
+	echo "$USAGE
+				THIS SCRIPT SHOULD ONLY BE USED BY -MONIT-!
+
+				If you want to restart an instance, use ./restart.sh
+
+				First 3 parameters are mandatory.
+				Don't forget that the process is monitored by 'monit'.
+				It will restart automatically if you stop the API.
+				If you want to stop it permanently, do 'sudo /etc/ini.d/monit stop' first.
+				"
+	exit 65
+fi
+
+REPO=$1
+ACTION=$2
+PORT=$3
+JAVA_OPTS="$4"
+
+HOME="/home/sol"
+
+# it is important to set the proper locale
+. $HOME/.locale
+JAVA_OPTS=$(echo "$JAVA_OPTS" |sed 's#,#\ #g')
+
+cd $HOME/git/$REPO
+case $ACTION in
+	start)
+		kill $(cat target/universal/stage/RUNNING_PID)
+		JAVA_OPTS="$JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError" $HOME/activator-1.3.10-minimal/bin/activator "start $PORT"
+		;;
+	stop)
+		kill $(cat target/universal/stage/RUNNING_PID)
+		;;
+	*)
+		echo "usage: $USAGE"
+		;;
+esac
+exit 0

--- a/restart.sh
+++ b/restart.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+USAGE="\nusage: <GIT REPO NAME>
+This script will just echo -en \033[1mSTOP\033[0m the process!
+First parameter is mandatory.
+The process is normally be monitored by 'monit'.
+Monit will automatically restart it when it's stopped.
+Have a look at /etc/monit/conf.d/play-instances.rc to see
+which paramters are used (port, java opts etc.)
+To see if monit is really observing your instances, try:
+$ lynx localhost:2812
+The username is 'admin', the password 'monit'.
+If you want to stop it permanently via cmd, do this first:
+$ sudo /etc/ini.d/monit stop
+"
+
+if [ ! $# -eq 1 ]; then
+	echo "$USAGE"
+	exit 65
+fi
+
+REPO=$1
+ACTION=$2
+HOME="/home/sol"
+
+# it is important to set the proper locale
+. $HOME/.locale
+JAVA_OPTS=$(echo "$JAVA_OPTS" |sed 's#,#\ #g')
+
+cd $HOME/git/$REPO
+kill $(cat target/universal/stage/RUNNING_PID)
+echo "Going to sleep for 11 seconds. Then lookup the process list for the repo name.
+If everything is fine, 'monit' is going to start the $REPO instance ..."
+sleep 11
+
+ps -ef | grep $REPO
+exit 0


### PR DESCRIPTION
Avoiding manually restarting of instances which may lack important
parameters.

This commit syncs to the start-scripts used by the lobid api.

See hbz/lobid#218.
See hbz/lobid#283.